### PR TITLE
Use std. license identifier and use 'license' not 'licence' key

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,7 +15,7 @@
     "repo-type" : "git",
     "source-url": "git://github.com/salortiz/p6-LMDB.git",
     "authors" : "Salvador Ortiz <sortiz@cpan.com>",
-    "licence" : "artistic_2",
+    "license" : "Artistic-2.0",
     "support" : {
 	"email" : "sog@msg.com.mx",
 	"source" : [


### PR DESCRIPTION
The proper key is "license" using the en_US spelling. Also use a
standard SPDX identifier for the license name.

For more details see: https://design.perl6.org/S22.html#license